### PR TITLE
Bump jQuery to 3.4.1

### DIFF
--- a/demo/demo.html
+++ b/demo/demo.html
@@ -9,7 +9,7 @@
                 margin: 2em;
             }
 
-            heading {
+            h2 {
                 display: block;
                 font-weight: bold;
             }
@@ -26,14 +26,13 @@
         <script>
             // Shim HTML5 elements in old IE
             document.createElement('section');
-            document.createElement('heading');
         </script>
     </head>
     <body>
         <h1>Dynamic.js demo</h1>
 
         <section>
-            <heading>I toggle the message's display via a data attribute</heading>
+            <h2>I toggle the message's display via a data attribute</h2>
             <label>
                 On
                 <input type="radio" name="toggle_radio_data" value="on" data-dyn-toggle-on="change" data-dyn-toggle="#toggle_message_data" checked>
@@ -47,7 +46,7 @@
         </section>
 
         <section>
-            <heading>I toggle the message's display via a data attribute and a selector function</heading>
+            <h2>I toggle the message's display via a data attribute and a selector function</h2>
             <label>
                 On
                 <input type="radio" name="toggle_radio_data_with_fn" value="on" data-dyn-toggle-on="change" data-dyn-toggle="@closest(section) > #toggle_message_data_with_fn" checked>
@@ -61,7 +60,7 @@
         </section>
 
         <section>
-            <heading>I toggle the messages' displays via a data attribute with expression</heading>
+            <h2>I toggle the messages' displays via a data attribute with expression</h2>
             <p>
                 <label>
                     First
@@ -87,7 +86,7 @@
         </section>
 
         <section>
-            <heading>I toggle the message's display via a JSON config</heading>
+            <h2>I toggle the message's display via a JSON config</h2>
             <div>
                 <label>
                     On

--- a/dist/dynamic.js
+++ b/dist/dynamic.js
@@ -1200,7 +1200,7 @@ _.extend(Dynamic.prototype, {
 
         dynamic.$context.find('script[type="text/x-dyn-json"]').each(function () {
             var json = $(this).html(),
-                config = $.parseJSON(json);
+                config = JSON.parse(json);
 
             _.forOwn(config, function (elementConfig, selector) {
                 function handleConfig(elementConfig) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1968,9 +1968,9 @@
       }
     },
     "jquery": {
-      "version": "1.12.4",
-      "resolved": "https://registry.npmjs.org/jquery/-/jquery-1.12.4.tgz",
-      "integrity": "sha1-AeHfuikP5z3rp3zurLD5ui/sngw="
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.4.1.tgz",
+      "integrity": "sha512-36+AdBzCL+y6qjw5Tx7HgzeGCzC81MDDgaUP8ld2zhx58HdqXGoBd+tHdrBMiyjGQs0Hxs/MLZTu/eHNJJuWPw=="
     },
     "jsep": {
       "version": "0.3.0",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "dependencies": {
     "expression-eval": "^1.2.3",
-    "jquery": "~1",
+    "jquery": "^3.4.1",
     "microdash": "~1.3"
   },
   "devDependencies": {

--- a/src/Dynamic.js
+++ b/src/Dynamic.js
@@ -51,7 +51,7 @@ _.extend(Dynamic.prototype, {
 
         dynamic.$context.find('script[type="text/x-dyn-json"]').each(function () {
             var json = $(this).html(),
-                config = $.parseJSON(json);
+                config = JSON.parse(json);
 
             _.forOwn(config, function (elementConfig, selector) {
                 function handleConfig(elementConfig) {


### PR DESCRIPTION
This PR contains the following:

- Bumped jQuery to 3.4.1
- Replaced deprecated `$.parseJSON` with `JSON.parse`
- Replaced invalid `heading` element on demo page